### PR TITLE
fix: validation fails due to how the wrapper is written

### DIFF
--- a/workflow/rules/multiqc.smk
+++ b/workflow/rules/multiqc.smk
@@ -15,8 +15,8 @@ rule multiqc:
             for ext in config.get("picard_collect_multiple_metrics", {}).get("output_ext", [""])
         ],
     output:
-        data=temp(directory("qc/multiqc/multiqc_data")),
-        html=temp("qc/multiqc/multiqc.html"),
+        temp("qc/multiqc/multiqc.html"),
+        temp(directory("qc/multiqc/multiqc_data")),
     params:
         extra="{} {}".format(
             config.get("multiqc", {}).get("extra", ""),


### PR DESCRIPTION
the wrapper doesn't use our naming of the output (html, data). It just fetches the first entry in output and names the html files as qc/multiqc/multiqc_data.html instead of qc/multiqc/multiqc.html