### PR TITLE
chore: migrate to release-please-action@v4 with GitHub App token

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,20 +1,27 @@
+name: release-please
+
 on:
   push:
     branches:
       - master
-  workflow_dispatch:
 
-name: release-please
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: master
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,15 @@
 {
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "python",
-      "bump-minor-pre-major": true,
-      "include-v-in-tag": true
+      "release-type": "simple",
+      "package-name": "qc",
+      "changelog-path": "CHANGELOG.md",
+      "include-v-in-tag": true,
+      "include-component-in-tag": false,
+      "draft": false,
+      "prerelease": false
     }
   },
-  "bootstrap-sha": "3f5a6403c7bb2cd4d195db663ccd947abfda98db"
+  "bootstrap-sha": "3f20283d7ea0b38e4cd2f65c595825f40e39d4de"
 }


### PR DESCRIPTION
Switch release-please-config.json to release-type simple (pipeline repo, no PyPI publish), add full package config, and update bootstrap-sha to v0.7.0. Replace workflow GITHUB_TOKEN with a GitHub App token via actions/create-github-app-token@v2.

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
- [ ] Module compatibility section in `README.md` is up to date
